### PR TITLE
Fix undefined variable error

### DIFF
--- a/ftplugin/sml.vim
+++ b/ftplugin/sml.vim
@@ -50,9 +50,11 @@ if exists('g:loaded_ale')
   call setbufvar(s:buf, 'ale_sml_smlnj_cm_file', bettersml#util#GetCmFilePattern())
 endif
 
-if !has_key(g:ale_linters, 'sml')
-  if ale#handlers#smlsharp#GetExecutableSmlsharpFile(bufnr('')) ==# 'smlsharp'
-    let g:ale_linters.sml = ['smlsharp_file']
+if exists('g:ale_linters')
+  if !has_key(g:ale_linters, 'sml')
+    if ale#handlers#smlsharp#GetExecutableSmlsharpFile(bufnr('')) ==# 'smlsharp'
+      let g:ale_linters.sml = ['smlsharp_file']
+    endif
   endif
 endif
 


### PR DESCRIPTION
Using Neovim 0.9.2, attempting to view an SML file throws an uncaught error that `g:ale_linters` is undefined. This commit checks for the existence of this variable before attempting to use it.

Here's the full error message:
```
Error opening file: vim/_editor.lua:341: nvim_exec2()..BufReadPost Autocommands for "*": Vim(append):Error executing lua callback: C:/Program Files/Neovim/share/nvim/runtime/filetype.lua:24: Error executing lua: C:/Program Files/Neovim/share/nvim/runtime/filetype.lua:25: nvim_exec2()..BufReadPost Autocommands for "*"..FileType Autocommands for "*"..function <SNR>1_LoadFTPlugin[19]..script C:\Users\Anthony\AppData\Local\LazyVim-data\lazy\vim-better-sml\ftplugin\sml.vim, line 54: Vim(if):E121: Undefined variable: g:ale_linters
stack traceback:
	[C]: in function 'nvim_cmd'
	C:/Program Files/Neovim/share/nvim/runtime/filetype.lua:25: in function <C:/Program Files/Neovim/share/nvim/runtime/filetype.lua:24>
	[C]: in function 'nvim_buf_call'
	C:/Program Files/Neovim/share/nvim/runtime/filetype.lua:24: in function <C:/Program Files/Neovim/share/nvim/runtime/filetype.lua:10>
	[C]: in function 'nvim_exec2'
	vim/_editor.lua:341: in function <vim/_editor.lua:337>
	[C]: in function 'pcall'
	...yVim-data/lazy/neo-tree.nvim/lua/neo-tree/utils/init.lua:714: in function 'open_file'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:729: in function 'open'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:751: in function 'open_with_cmd'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:760: in function 'open'
	...o-tree.nvim/lua/neo-tree/sources/filesystem/commands.lua:184: in function <...o-tree.nvim/lua/neo-tree/sources/filesystem/commands.lua:183>
stack traceback:
	[C]: in function 'nvim_buf_call'
	C:/Program Files/Neovim/share/nvim/runtime/filetype.lua:24: in function <C:/Program Files/Neovim/share/nvim/runtime/filetype.lua:10>
	[C]: in function 'nvim_exec2'
	vim/_editor.lua:341: in function <vim/_editor.lua:337>
	[C]: in function 'pcall'
	...yVim-data/lazy/neo-tree.nvim/lua/neo-tree/utils/init.lua:714: in function 'open_file'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:729: in function 'open'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:751: in function 'open_with_cmd'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:760: in function 'open'
	...o-tree.nvim/lua/neo-tree/sources/filesystem/commands.lua:184: in function <...o-tree.nvim/lua/neo-tree/sources/filesystem/commands.lua:183>
```