### PR TITLE
lines beginning with | after a fun no longer indent

### DIFF
--- a/indent/sml.vim
+++ b/indent/sml.vim
@@ -182,6 +182,8 @@ function! GetSMLIndent() abort
     endif
     if switchLine =~ '\<case\>'
       return col(".") + 2
+    elseif switchLine =~ '\<fun\>'
+        return switchLineIndent
     elseif switchLine =~ '\<handle\>'
       return switchLineIndent + &sw
     elseif switchLine =~ '\<datatype\>'


### PR DESCRIPTION
All of the SML tools I've used format code differently from what I expect; lines beginning with `|` are indented, but the convention I'm used to is that if it's an alternate pattern for the `fun`, the `|` should match and not be indented further:

```sml
fun fact 0 = 1
|   fact n = n * fact (n-1);
```

I modified the indentation logic to change this behavior. I'm new to vimscript and plugins; I will happily accept edits or implement suggestions.